### PR TITLE
[YOUHAK-27] 회원가입 서비스 구현

### DIFF
--- a/Youhak/build.gradle
+++ b/Youhak/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     developmentOnly "org.springframework.boot:spring-boot-devtools:${devtoolsVersion}"
     testImplementation "org.springframework.boot:spring-boot-starter-test:${springbootVersion}"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:${junitVersion}"
+
+    // 외부 의존성
+    implementation "at.favre.lib:bcrypt:${BCryptVersion}"
 }
 
 tasks.named('test') {

--- a/Youhak/gradle.properties
+++ b/Youhak/gradle.properties
@@ -5,3 +5,4 @@ devtoolsVersion=3.4.5
 flywayVersion=11.8.0
 junitVersion=1.12.2
 lombokVersion=1.18.38
+BCryptVersion=0.10.2

--- a/Youhak/src/main/java/net/youhak/YouhakApplication.java
+++ b/Youhak/src/main/java/net/youhak/YouhakApplication.java
@@ -2,14 +2,16 @@ package net.youhak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
+@EnableJpaAuditing
+@PropertySource(value = "classpath:.env")
 public class YouhakApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(YouhakApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(YouhakApplication.class, args);
+	}
 
 }

--- a/Youhak/src/main/java/net/youhak/member/api/AuthController.java
+++ b/Youhak/src/main/java/net/youhak/member/api/AuthController.java
@@ -1,0 +1,32 @@
+package net.youhak.member.api;
+
+import lombok.RequiredArgsConstructor;
+import net.youhak.member.dto.request.LoginRequest;
+import net.youhak.member.dto.request.RegisterRequest;
+import net.youhak.member.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> registerMember(@RequestBody RegisterRequest registerRequest) {
+        authService.registerMember(registerRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> loginMember(@RequestBody LoginRequest loginRequest) {
+        authService.loginMember(loginRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/api/AuthController.java
+++ b/Youhak/src/main/java/net/youhak/member/api/AuthController.java
@@ -27,6 +27,6 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<Void> loginMember(@RequestBody LoginRequest loginRequest) {
         authService.loginMember(loginRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/Youhak/src/main/java/net/youhak/member/api/RoleController.java
+++ b/Youhak/src/main/java/net/youhak/member/api/RoleController.java
@@ -1,9 +1,9 @@
-package net.youhak.member.role.api;
+package net.youhak.member.api;
 
 import lombok.RequiredArgsConstructor;
-import net.youhak.member.role.api.dto.request.RoleCategoryRegisterRequest;
-import net.youhak.member.role.api.dto.request.RoleRegisterRequest;
-import net.youhak.member.role.service.RoleService;
+import net.youhak.member.dto.request.RoleCategoryRegisterRequest;
+import net.youhak.member.dto.request.RoleRegisterRequest;
+import net.youhak.member.service.RoleService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/Youhak/src/main/java/net/youhak/member/dto/request/LoginRequest.java
+++ b/Youhak/src/main/java/net/youhak/member/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package net.youhak.member.dto.request;
+
+public record LoginRequest(
+        String email,
+        String password
+) {
+}

--- a/Youhak/src/main/java/net/youhak/member/dto/request/RegisterRequest.java
+++ b/Youhak/src/main/java/net/youhak/member/dto/request/RegisterRequest.java
@@ -1,0 +1,10 @@
+package net.youhak.member.dto.request;
+
+public record RegisterRequest(
+        String email,
+        String password,
+        String name,
+        String nickname,
+        int gender
+) {
+}

--- a/Youhak/src/main/java/net/youhak/member/dto/request/RoleCategoryRegisterRequest.java
+++ b/Youhak/src/main/java/net/youhak/member/dto/request/RoleCategoryRegisterRequest.java
@@ -1,4 +1,4 @@
-package net.youhak.member.role.api.dto.request;
+package net.youhak.member.dto.request;
 
 public record RoleCategoryRegisterRequest(
         String name

--- a/Youhak/src/main/java/net/youhak/member/dto/request/RoleRegisterRequest.java
+++ b/Youhak/src/main/java/net/youhak/member/dto/request/RoleRegisterRequest.java
@@ -1,4 +1,4 @@
-package net.youhak.member.role.api.dto.request;
+package net.youhak.member.dto.request;
 
 public record RoleRegisterRequest(
         String name,

--- a/Youhak/src/main/java/net/youhak/member/entity/Login.java
+++ b/Youhak/src/main/java/net/youhak/member/entity/Login.java
@@ -1,0 +1,26 @@
+package net.youhak.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.youhak.shared.entity.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Login extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    public Login(Member member, String password) {
+        this.member = member;
+        this.password = password;
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/entity/Member.java
+++ b/Youhak/src/main/java/net/youhak/member/entity/Member.java
@@ -1,0 +1,42 @@
+package net.youhak.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.youhak.member.entity.vo.Gender;
+import net.youhak.member.entity.vo.GenderConverter;
+import net.youhak.shared.entity.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Member extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    @Convert(converter = GenderConverter.class)
+    private Gender gender;
+
+    @OneToOne(mappedBy = "member")
+    private Login login;
+
+    @Builder
+    public Member(String name, String nickname, String email, Gender gender) {
+        this.name = name;
+        this.nickname = nickname;
+        this.email = email;
+        this.gender = gender;
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/entity/Role.java
+++ b/Youhak/src/main/java/net/youhak/member/entity/Role.java
@@ -1,4 +1,4 @@
-package net.youhak.member.role.domain;
+package net.youhak.member.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -6,7 +6,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import net.youhak.global.BaseEntity;
+import net.youhak.shared.entity.BaseEntity;
 
 @Entity
 @RequiredArgsConstructor

--- a/Youhak/src/main/java/net/youhak/member/entity/RoleCategory.java
+++ b/Youhak/src/main/java/net/youhak/member/entity/RoleCategory.java
@@ -1,4 +1,4 @@
-package net.youhak.member.role.domain;
+package net.youhak.member.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import net.youhak.global.BaseEntity;
+import net.youhak.shared.entity.BaseEntity;
 
 @Entity
 @RequiredArgsConstructor

--- a/Youhak/src/main/java/net/youhak/member/entity/vo/Gender.java
+++ b/Youhak/src/main/java/net/youhak/member/entity/vo/Gender.java
@@ -1,0 +1,31 @@
+package net.youhak.member.entity.vo;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+
+    NOT_SELECTED(0),
+    MALE(1),
+    FEMALE(2);
+
+    private final int genderCode;
+
+    Gender(int genderCode) {
+        this.genderCode = genderCode;
+    }
+
+    private static final Map<Integer, Gender> GENDER_MAP = new HashMap<>();
+
+    static {
+        for (Gender gender : values()) {
+            GENDER_MAP.put(gender.genderCode, gender);
+        }
+    }
+
+    public static Gender getGender(int genderCode) {
+        return GENDER_MAP.getOrDefault(genderCode, NOT_SELECTED);
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/entity/vo/GenderConverter.java
+++ b/Youhak/src/main/java/net/youhak/member/entity/vo/GenderConverter.java
@@ -1,0 +1,18 @@
+package net.youhak.member.entity.vo;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class GenderConverter implements AttributeConverter<Gender, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(Gender gender) {
+        return gender != null ? gender.getGenderCode() : Gender.NOT_SELECTED.getGenderCode();
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(Integer dbData) {
+        return dbData != null ? Gender.getGender(dbData) : Gender.NOT_SELECTED;
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/repository/AuthRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/AuthRepository.java
@@ -1,0 +1,12 @@
+package net.youhak.member.repository;
+
+import net.youhak.member.entity.Login;
+import net.youhak.member.entity.Member;
+
+
+public interface AuthRepository {
+
+    void registerMember(Member member, Login login);
+
+    Member getMemberByEmail(String email);
+}

--- a/Youhak/src/main/java/net/youhak/member/repository/AuthRepositoryImpl.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/AuthRepositoryImpl.java
@@ -1,0 +1,29 @@
+package net.youhak.member.repository;
+
+import lombok.RequiredArgsConstructor;
+import net.youhak.member.entity.Login;
+import net.youhak.member.entity.Member;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthRepositoryImpl implements AuthRepository {
+
+    private final MemberJpaRepository memberJpaRepository;
+    private final LoginJpaRepository loginJpaRepository;
+
+    @Transactional
+    @Override
+    public void registerMember(Member member, Login login) {
+        memberJpaRepository.save(member);
+        loginJpaRepository.save(login);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Member getMemberByEmail(String email) {
+        return memberJpaRepository.findByEmail(email)
+                .orElseThrow();
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/repository/LoginJpaRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/LoginJpaRepository.java
@@ -1,0 +1,7 @@
+package net.youhak.member.repository;
+
+import net.youhak.member.entity.Login;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoginJpaRepository extends JpaRepository<Login, Long> {
+}

--- a/Youhak/src/main/java/net/youhak/member/repository/MemberJpaRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/MemberJpaRepository.java
@@ -3,8 +3,16 @@ package net.youhak.member.repository;
 import java.util.Optional;
 import net.youhak.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+
+    @Query("""
+        select m
+        from Member m
+        where m.email = :email
+            and m.isDeleted = false
+    """)
     Optional<Member> findByEmail(@Param("email") String email);
 }

--- a/Youhak/src/main/java/net/youhak/member/repository/MemberJpaRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/MemberJpaRepository.java
@@ -1,0 +1,10 @@
+package net.youhak.member.repository;
+
+import java.util.Optional;
+import net.youhak.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(@Param("email") String email);
+}

--- a/Youhak/src/main/java/net/youhak/member/repository/RoleCategoryJpaRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/RoleCategoryJpaRepository.java
@@ -1,7 +1,7 @@
-package net.youhak.member.role.repository;
+package net.youhak.member.repository;
 
 import java.util.Optional;
-import net.youhak.member.role.domain.RoleCategory;
+import net.youhak.member.entity.RoleCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/Youhak/src/main/java/net/youhak/member/repository/RoleJpaRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/RoleJpaRepository.java
@@ -1,6 +1,6 @@
-package net.youhak.member.role.repository;
+package net.youhak.member.repository;
 
-import net.youhak.member.role.domain.Role;
+import net.youhak.member.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/Youhak/src/main/java/net/youhak/member/repository/RoleRepository.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/RoleRepository.java
@@ -1,7 +1,7 @@
-package net.youhak.member.role.repository;
+package net.youhak.member.repository;
 
-import net.youhak.member.role.domain.Role;
-import net.youhak.member.role.domain.RoleCategory;
+import net.youhak.member.entity.Role;
+import net.youhak.member.entity.RoleCategory;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/Youhak/src/main/java/net/youhak/member/repository/RoleRepositoryImpl.java
+++ b/Youhak/src/main/java/net/youhak/member/repository/RoleRepositoryImpl.java
@@ -1,8 +1,8 @@
-package net.youhak.member.role.repository;
+package net.youhak.member.repository;
 
 import lombok.RequiredArgsConstructor;
-import net.youhak.member.role.domain.Role;
-import net.youhak.member.role.domain.RoleCategory;
+import net.youhak.member.entity.Role;
+import net.youhak.member.entity.RoleCategory;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/Youhak/src/main/java/net/youhak/member/service/AuthService.java
+++ b/Youhak/src/main/java/net/youhak/member/service/AuthService.java
@@ -1,0 +1,9 @@
+package net.youhak.member.service;
+
+import net.youhak.member.dto.request.LoginRequest;
+import net.youhak.member.dto.request.RegisterRequest;
+
+public interface AuthService {
+    void registerMember(RegisterRequest registerRequest);
+    void loginMember(LoginRequest loginRequest);
+}

--- a/Youhak/src/main/java/net/youhak/member/service/AuthService.java
+++ b/Youhak/src/main/java/net/youhak/member/service/AuthService.java
@@ -4,6 +4,8 @@ import net.youhak.member.dto.request.LoginRequest;
 import net.youhak.member.dto.request.RegisterRequest;
 
 public interface AuthService {
+
     void registerMember(RegisterRequest registerRequest);
+
     void loginMember(LoginRequest loginRequest);
 }

--- a/Youhak/src/main/java/net/youhak/member/service/AuthServiceImpl.java
+++ b/Youhak/src/main/java/net/youhak/member/service/AuthServiceImpl.java
@@ -1,0 +1,52 @@
+package net.youhak.member.service;
+
+import net.youhak.member.entity.Login;
+import net.youhak.member.entity.Member;
+import net.youhak.member.dto.request.LoginRequest;
+import net.youhak.member.dto.request.RegisterRequest;
+import net.youhak.member.entity.vo.Gender;
+import net.youhak.member.repository.AuthRepository;
+import net.youhak.member.util.PasswordUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    private final AuthRepository authRepository;
+    private final PasswordUtil passwordUtil;
+
+    public AuthServiceImpl(AuthRepository authRepository, PasswordUtil passwordUtil) {
+        this.authRepository = authRepository;
+        this.passwordUtil = passwordUtil;
+    }
+
+    @Override
+    public void registerMember(RegisterRequest registerRequest) {
+        String hashedPassword = passwordUtil.hashPassword(registerRequest.password());
+
+        Member member = Member.builder()
+                .email(registerRequest.email())
+                .nickname(registerRequest.nickname())
+                .gender(Gender.getGender(registerRequest.gender()))
+                .name(registerRequest.name())
+                .build();
+
+        Login login = Login.builder()
+                .member(member)
+                .password(hashedPassword)
+                .build();
+
+        authRepository.registerMember(member, login);
+    }
+
+    @Override
+    public void loginMember(LoginRequest loginRequest) {
+        Member member = authRepository.getMemberByEmail(loginRequest.email());
+
+        boolean passwordMatches = passwordUtil.verifyPassword(loginRequest.password(), member.getLogin().getPassword());
+
+        if (!passwordMatches) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+    }
+}

--- a/Youhak/src/main/java/net/youhak/member/service/RoleService.java
+++ b/Youhak/src/main/java/net/youhak/member/service/RoleService.java
@@ -1,7 +1,7 @@
-package net.youhak.member.role.service;
+package net.youhak.member.service;
 
-import net.youhak.member.role.api.dto.request.RoleCategoryRegisterRequest;
-import net.youhak.member.role.api.dto.request.RoleRegisterRequest;
+import net.youhak.member.dto.request.RoleCategoryRegisterRequest;
+import net.youhak.member.dto.request.RoleRegisterRequest;
 
 public interface RoleService {
 

--- a/Youhak/src/main/java/net/youhak/member/service/RoleServiceImpl.java
+++ b/Youhak/src/main/java/net/youhak/member/service/RoleServiceImpl.java
@@ -1,12 +1,12 @@
-package net.youhak.member.role.service;
+package net.youhak.member.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import net.youhak.member.role.api.dto.request.RoleCategoryRegisterRequest;
-import net.youhak.member.role.api.dto.request.RoleRegisterRequest;
-import net.youhak.member.role.domain.Role;
-import net.youhak.member.role.domain.RoleCategory;
-import net.youhak.member.role.repository.RoleRepository;
+import net.youhak.member.dto.request.RoleCategoryRegisterRequest;
+import net.youhak.member.dto.request.RoleRegisterRequest;
+import net.youhak.member.entity.Role;
+import net.youhak.member.entity.RoleCategory;
+import net.youhak.member.repository.RoleRepository;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/Youhak/src/main/java/net/youhak/member/util/PasswordUtil.java
+++ b/Youhak/src/main/java/net/youhak/member/util/PasswordUtil.java
@@ -1,0 +1,8 @@
+package net.youhak.member.util;
+
+public interface PasswordUtil {
+
+    String hashPassword(String password);
+
+    boolean verifyPassword(String password, String hashedPassword);
+}

--- a/Youhak/src/main/java/net/youhak/member/util/PasswordUtilImpl.java
+++ b/Youhak/src/main/java/net/youhak/member/util/PasswordUtilImpl.java
@@ -1,0 +1,19 @@
+package net.youhak.member.util;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordUtilImpl implements PasswordUtil{
+
+    @Override
+    public String hashPassword(String password) {
+        return BCrypt.withDefaults().hashToString(12, password.toCharArray());
+    }
+
+    @Override
+    public boolean verifyPassword(String password, String hashedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(password.toCharArray(), hashedPassword);
+        return result.verified;
+    }
+}

--- a/Youhak/src/main/java/net/youhak/shared/entity/BaseEntity.java
+++ b/Youhak/src/main/java/net/youhak/shared/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package net.youhak.global;
+package net.youhak.shared.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/Youhak/src/main/resources/db/migration/V2__Delete_account_column_login_table.sql
+++ b/Youhak/src/main/resources/db/migration/V2__Delete_account_column_login_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE login DROP COLUMN account;

--- a/docs/convention.md
+++ b/docs/convention.md
@@ -61,7 +61,15 @@
 
 ## ✅ 코드 컨벤션
 
-우리 프로젝트에서는 Java 코드는 [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)를 기반으로 작성된 [우아한테크코스 자바 스타일 가이드](https://github.com/woowacourse/woowacourse-docs/tree/main/styleguide/java)를 따릅니다.
+- 우리 프로젝트에서는 Java 코드는 [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)를 기반으로 작성된 [우아한테크코스 자바 스타일 가이드](https://github.com/woowacourse/woowacourse-docs/tree/main/styleguide/java)를 따릅니다.
+- 패키지 구조는 계층 기반이 아닌 **책임 기반 모듈 구조**를 따릅니다.
+
+| 패키지명   | 역할 설명                                                           |
+| ---------- | ------------------------------------------------------------------- |
+| `shared`   | 공통 유틸, 상수, 예외, 어노테이션 등 **범용적으로 재사용되는 자원** |
+| `global`   | 전역 설정, AOP, 예외 처리 등 **Spring 애플리케이션 전반 설정 구성** |
+| `external` | **외부 시스템** (API, DB, 메시지 등)과의 통신 어댑터                |
+| `domain`   | **핵심 비즈니스 도메인 모델과 로직**                                |
 
 ### 추가 규칙
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) closes: #27 

## 📝 작업 내용

- 회원가입 서비스 구현
- gender converter 구현
- 파일 패키지 구조 변경
- db 암호화 저장을 위한 외부 라이브러리 사용
    - spring Security를 사용하지 않은 이유는 러닝커브가 너무 크다고 생각해서 그랬습니다.
- repostiory와 service 역할 구분 
    - repository에 transactional추가

## 💬 리뷰 요구사항
- 패키지 구조 변경
- repository와 service의 분리
     - repository는 db역할
     - service는 비즈니스 로직에 집중
- spring security를 사용하지 않은 비밀번호 저장로직구현
     - 단방향 암호화를 통해 복호화가 불가능한 라이브러리 사용
     - 파일 패키지상 external에 둘지 고민을 해봤음 좋은 의견이 있으면 말좀해주세요. 저는 member에서만 한정적으로 사용할 것 같아 domain.member안에 구현하였습니다. 

## ⏰ 작업 소요시간
- 2시간